### PR TITLE
Fix GitHub indexing scripts to use POST instead of GET

### DIFF
--- a/.github/workflows/index_dump.py
+++ b/.github/workflows/index_dump.py
@@ -16,7 +16,7 @@ def set_args():
 
 def send_request(url, headers):
     try:
-        response = requests.get(url,headers=headers)
+        response = requests.post(url,headers=headers)
     except requests.exceptions.RequestException as e:
         raise e
     return response

--- a/.github/workflows/index_files.py
+++ b/.github/workflows/index_files.py
@@ -15,7 +15,7 @@ def set_args():
 
 def send_request(url, headers):
     try:
-        response = requests.get(url,headers=headers)
+        response = requests.post(url,headers=headers)
     except requests.exceptions.RequestException as e:
         raise e
     return response


### PR DESCRIPTION
## Purpose

Update the HTTP method used by the GitHub workflow indexing scripts from GET to POST so that indexing requests are sent correctly to the intended endpoints.

## Approach

Changed the request method in both indexing utility scripts from `requests.get` to `requests.post`. This aligns the workflows with the expected API semantics for triggering indexing operations.

### Key Modifications

- `.github/workflows/index_dump.py`: Updated `send_request` to use `requests.post` instead of `requests.get`.
- `.github/workflows/index_files.py`: Updated `send_request` to use `requests.post` instead of `requests.get`.

### Important Technical Details

- Both scripts share a similar `send_request` helper function; the change is consistent across both.
- No additional payload or parameters were added; only the HTTP verb was changed.
- These scripts are used by GitHub Actions workflows for indexing operations.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.